### PR TITLE
Remove hokey api endpoint detection

### DIFF
--- a/lib/puppet/provider/netscaler_lbmonitor/rest.rb
+++ b/lib/puppet/provider/netscaler_lbmonitor/rest.rb
@@ -2,6 +2,10 @@ require 'puppet/provider/netscaler'
 require 'json'
 
 Puppet::Type.type(:netscaler_lbmonitor).provide(:rest, parent: Puppet::Provider::Netscaler) do
+  def netscaler_api_type
+    "lbmonitor"
+  end
+
   def self.instances
     instances = []
     monitors = Puppet::Provider::Netscaler.call('/config/lbmonitor')

--- a/lib/puppet/provider/netscaler_server/rest.rb
+++ b/lib/puppet/provider/netscaler_server/rest.rb
@@ -2,6 +2,10 @@ require 'puppet/provider/netscaler'
 require 'json'
 
 Puppet::Type.type(:netscaler_server).provide(:rest, parent: Puppet::Provider::Netscaler) do
+  def netscaler_api_type
+    "server"
+  end
+
   def self.instances
     instances = []
     servers = Puppet::Provider::Netscaler.call('/config/server')

--- a/lib/puppet/provider/netscaler_service/rest.rb
+++ b/lib/puppet/provider/netscaler_service/rest.rb
@@ -2,6 +2,10 @@ require 'puppet/provider/netscaler'
 require 'json'
 
 Puppet::Type.type(:netscaler_service).provide(:rest, parent: Puppet::Provider::Netscaler) do
+  def netscaler_api_type
+    "service"
+  end
+
   def self.instances
     instances = []
     services = Puppet::Provider::Netscaler.call('/config/service')


### PR DESCRIPTION
Previously the types would take the second index after splitting the
type on `_` to determine the api endpoint. This won't work, and is
janky.

This commit requires each provider to specify a `provider_api_type` that
returns a string of its api endpoint after `/v1/config`