### PR TITLE
Rename lb_monitor back to lbmonitor

### DIFF
--- a/lib/puppet/provider/netscaler_lbmonitor/rest.rb
+++ b/lib/puppet/provider/netscaler_lbmonitor/rest.rb
@@ -1,7 +1,7 @@
 require 'puppet/provider/netscaler'
 require 'json'
 
-Puppet::Type.type(:netscaler_lb_monitor).provide(:rest, parent: Puppet::Provider::Netscaler) do
+Puppet::Type.type(:netscaler_lbmonitor).provide(:rest, parent: Puppet::Provider::Netscaler) do
   def netscaler_api_type
     "lbmonitor"
   end

--- a/lib/puppet/type/netscaler_lbmonitor.rb
+++ b/lib/puppet/type/netscaler_lbmonitor.rb
@@ -2,7 +2,7 @@ require 'puppet/parameter/netscaler_name'
 require 'puppet/property/netscaler_truthy'
 require 'puppet/property/netscaler_traffic_domain'
 
-Puppet::Type.newtype(:netscaler_lb_monitor) do
+Puppet::Type.newtype(:netscaler_lbmonitor) do
   @doc = 'Manage service on the NetScaler appliance. If the service is domain based, before you create the service, create the server entry by using the add server command. Then, in this command, specify the Server parameter.'
 
   apply_to_device


### PR DESCRIPTION
The bindings take the form of `netscaler_<thing1>_<thing2>_bind` and so
I'd rather avoid the "things" having underscores in their names.