### PR TITLE
Add lbvserver -> service -> lbmonitor binds

### DIFF
--- a/lib/puppet/provider/netscaler_binding.rb
+++ b/lib/puppet/provider/netscaler_binding.rb
@@ -1,0 +1,20 @@
+require 'puppet/provider/netscaler'
+
+class Puppet::Provider::NetscalerBinding < Puppet::Provider::Netscaler
+  def flush
+    if @property_hash != {}
+      #XXX Maybe we should delete/create them?
+      err "Bindings may not be modified after creation"
+    end
+  end
+
+  def immutable_properties
+    []
+  end
+
+  # We have to override this because some properties actually have
+  # underscores... (like monitor_name)
+  def remove_underscores(hash)
+    hash
+  end
+end

--- a/lib/puppet/provider/netscaler_lbvserver_service_bind/rest.rb
+++ b/lib/puppet/provider/netscaler_lbvserver_service_bind/rest.rb
@@ -1,0 +1,39 @@
+require 'puppet/provider/netscaler_binding'
+
+Puppet::Type.type(:netscaler_lbvserver_service_bind).provide(:rest, parent: Puppet::Provider::NetscalerBinding) do
+  def netscaler_api_type
+    "lbvserver_service_binding"
+  end
+
+  def self.instances
+    instances = []
+    lbvservers = Puppet::Provider::Netscaler.call("/config/lbvserver")
+    return [] if lbvservers.nil?
+
+    lbvservers.each do |lbvserver|
+      binds = Puppet::Provider::Netscaler.call("/config/lbvserver_service_binding/#{lbvserver['name']}")
+      binds.each do |bind|
+        instances << new(
+          :ensure => :present,
+          :name   => "#{bind['name']}/#{bind['servicename']}",
+          :weight => bind['weight'],
+        )
+      end
+    end
+
+    instances
+  end
+
+  mk_resource_methods
+
+  def property_to_rest_mapping
+    {
+    }
+  end
+
+  def per_provider_munge(message)
+    message[:name], message[:servicename] = message[:name].split('/')
+
+    message
+  end
+end

--- a/lib/puppet/provider/netscaler_service_lbmonitor_bind/rest.rb
+++ b/lib/puppet/provider/netscaler_service_lbmonitor_bind/rest.rb
@@ -1,0 +1,42 @@
+require 'puppet/provider/netscaler_binding'
+
+Puppet::Type.type(:netscaler_service_lbmonitor_bind).provide(:rest, parent: Puppet::Provider::NetscalerBinding) do
+  def netscaler_api_type
+    "service_lbmonitor_binding"
+  end
+
+  def self.instances
+    instances = []
+    services = Puppet::Provider::Netscaler.call("/config/service")
+    return [] if services.nil?
+
+    services.each do |service|
+      binds = Puppet::Provider::Netscaler.call("/config/service_lbmonitor_binding/#{service['name']}")
+      binds.each do |bind|
+        instances << new(
+          :ensure => :present,
+          :name   => "#{bind['name']}/#{bind['monitor_name']}",
+          :weight => bind['weight'],
+          :state  => bind['monstate'],
+        )
+      end
+    end
+
+    instances
+  end
+
+  mk_resource_methods
+
+  def property_to_rest_mapping
+    {
+      :state          => :monstate,
+    }
+  end
+
+  def per_provider_munge(message)
+    message[:name], message[:monitor_name] = message[:name].split('/')
+
+    message
+  end
+end
+

--- a/lib/puppet/type/netscaler_lbvserver_service_bind.rb
+++ b/lib/puppet/type/netscaler_lbvserver_service_bind.rb
@@ -1,0 +1,30 @@
+require 'puppet/property/netscaler_truthy'
+
+Puppet::Type.newtype(:netscaler_lbvserver_service_bind) do
+  @doc = 'Manage a binding between a loadbalanceing vserver and a service.'
+
+  apply_to_device
+  ensurable
+
+  newparam(:name, :namevar => true) do
+    desc "lbvserver_name/service_name"
+  end
+
+  newproperty(:weight) do
+    desc "Weight to assign to the specified service.
+
+Min = 1
+Max = 100"
+    newvalues(/^\d+$/)
+    munge do |value|
+      Integer(value)
+    end
+  end
+
+  autorequire(:netscaler_lbvserver) do
+    self[:name].split('/')[0]
+  end
+  autorequire(:netscaler_service) do
+    self[:name].split('/')[1]
+  end
+end

--- a/lib/puppet/type/netscaler_service_lbmonitor_bind.rb
+++ b/lib/puppet/type/netscaler_service_lbmonitor_bind.rb
@@ -1,0 +1,38 @@
+require 'puppet/property/netscaler_truthy'
+
+Puppet::Type.newtype(:netscaler_service_lbmonitor_bind) do
+  @doc = 'Manage a binding between a service and a loadbalancing monitor.'
+
+  apply_to_device
+  ensurable
+
+  newparam(:name, :namevar => true) do
+    desc "service_name/lbmonitor_name"
+  end
+
+  newproperty(:weight) do
+    desc "Weight to assign to the monitor-service binding. When a monitor is UP, the weight assigned to its binding with the service determines how much the monitor contributes toward keeping the health of the service above the value configured for the Monitor Threshold parameter.
+
+    Min = 1
+    Max = 100"
+    newvalues(/^\d+$/)
+    munge do |value|
+      Integer(value)
+    end
+  end
+
+  newproperty(:state, :parent => Puppet::Property::NetscalerTruthy) do
+    truthy_property('The configured state (enable/disable) of the bound monitor.','ENABLED','DISABLED')
+  end
+
+  newproperty(:passive, :parent => Puppet::Property::NetscalerTruthy) do
+    truthy_property('Indicates if the monitor is passive. A passive monitor does not remove service from LB decision when the threshold is breached.','ENABLED','DISABLED')
+  end
+
+  autorequire(:netscaler_service) do
+    self[:name].split('/')[0]
+  end
+  autorequire(:netscaler_lbmonitor) do
+    self[:name].split('/')[1]
+  end
+end


### PR DESCRIPTION
A few of the issues:
- binding is a many-to-many relationship operation, so the titles have
  to have both the left and right titles of the bound objects instead of
  passing them through parameters to avoid duplicate resource issues. I
  decided to split on / because that isn't a valid character for object
  titles in netscaler.
- All bindings have extra parameters that may be passed, but perhaps
  most often users won't care. In that case we should add the abitily to
  just pass `lbmonitor_bindings => [<monitor titles>]` to the
  `netscaler_service` resource to add the bindings without options, and
  do so for all objects.
- The ability to purge unmanaged bindings would be awesome. I'm thinking
  each type (like `netscaler_lbvserver`) would have a
  `purge_unmanaged_bindings => true|false` attribute that could be
  passed to do so.
- passive is an attribute for service_lbmonitor_binding but doesn't
  appear in the gui, but I added it anyway.
- monitor_name is the only property that has an underscore in it in all
  of netscaler so far, but I still had to override removing underscores
  for it
- bindings can't be edited after creation. I don't know if deleting them
  and recreating them really would be possible either.

Requires #13