### PR TITLE
Fix beaker connection reset errors

### DIFF
--- a/spec/fixtures/lib/beaker/hypervisor/netscaler.rb
+++ b/spec/fixtures/lib/beaker/hypervisor/netscaler.rb
@@ -17,7 +17,7 @@ module Beaker
 
       # Wait for each node's status checks to be :ok, otherwise the netscaler
       # application (mcpd) may not be started yet
-      #wait_for_status_checks("ok")
+      wait_for_status_checks("ok")
 
       # Add metadata tags to each instance
       add_tags()


### PR DESCRIPTION
If aws is busy, then the netscaler instance can be handed back before
it's ready. The wait_for_status() method should cause beaker to wait
longer until it is ready.