### PR TITLE
Fix preferred_ntp_server

### DIFF
--- a/lib/puppet/provider/netscaler_ntpserver/rest.rb
+++ b/lib/puppet/provider/netscaler_ntpserver/rest.rb
@@ -42,10 +42,22 @@ Puppet::Type.type(:netscaler_ntpserver).provide(:rest, parent: Puppet::Provider:
   end
   def per_provider_munge(message)
     # Not accepted on create
-    # XXX But can we fix this so it can?
     if ! @original_values[:ensure]
       message.delete(:preferred_ntp_server)
     end
     message
+  end
+
+  def create
+    result = super
+    if (result.status == 200 or result.status == 201) and resource[:preferred_ntp_server]
+      result = Puppet::Provider::Netscaler.put("/config/#{netscaler_api_type}/#{resource[:name]}", {
+        netscaler_api_type => {
+          :servername         => resource[:name],
+          :preferredntpserver => resource[:preferred_ntp_server],
+        }
+      }.to_json)
+    end
+    result
   end
 end

--- a/lib/puppet/type/netscaler_ntpserver.rb
+++ b/lib/puppet/type/netscaler_ntpserver.rb
@@ -34,7 +34,7 @@ Maximum value = 65534"
   end
 
   newproperty(:preferred_ntp_server,:parent => Puppet::Property::NetscalerTruthy) do #<String>
-    truthy_property("Preferred NTP server. The NetScaler appliance chooses this NTP server for time synchronization among a set of correctly operating hosts. Note: This property will not be enforced by puppet on a resource that is being created, only one one that already exists.
+    truthy_property("Preferred NTP server. The NetScaler appliance chooses this NTP server for time synchronization among a set of correctly operating hosts.
 Default value: NO
 Possible values = YES, NO","YES","NO")
   end

--- a/spec/acceptance/netscaler_ntpserver_spec.rb
+++ b/spec/acceptance/netscaler_ntpserver_spec.rb
@@ -9,6 +9,7 @@ describe 'ntpserver tests' do
         maximum_poll_interval => '55',
         auto_key              => true,
         key                   => '55',
+        preferred_ntp_server  => 'yes',
       }
     EOS
     make_site_pp(pp)


### PR DESCRIPTION
The preferred_ntp_server attribute could not be enforced on creation as
the rest api would not accept it. This change inherits `create` and
updates the setting after the resource is created.