### PR TITLE
Specify rest mapping for name to ip_address

### DIFF
--- a/lib/puppet/provider/netscaler_nsip/rest.rb
+++ b/lib/puppet/provider/netscaler_nsip/rest.rb
@@ -50,6 +50,7 @@ Puppet::Type.type(:netscaler_nsip).provide(:rest, parent: Puppet::Provider::Nets
   # Map for conversion in the message.
   def property_to_rest_mapping
     {
+      :name                     => :ip_address,
       :ip_type                  => :type,
       :virtual_router_id        => :vird,
       :traffic_domain           => :td,


### PR DESCRIPTION
Fixed this error:
Could not evaluate: REST failure: HTTP status code 599 detected.  Body of failure is: { "errorcode": 278, "message": "Invalid argument [name]", "severity": "ERROR" }

Working with Netscaler 10.5 55.8.nc.

It would be awesome if I could run the beaker acceptance tests, they appear to depend on some internal puppetlabs ami's.