### PR TITLE
Fix JSON.parse creating int's when they need to be strings

### DIFF
--- a/lib/puppet/provider/netscaler_nsip/rest.rb
+++ b/lib/puppet/provider/netscaler_nsip/rest.rb
@@ -27,7 +27,7 @@ Puppet::Type.type(:netscaler_nsip).provide(:rest, parent: Puppet::Provider::Nets
         :dynamic_routing          => ip['dynamicrouting'],
         :host_route               => ip['hostroute'],
         :host_route_gateway_ip    => ip['hostrtgw'],
-        :host_route_metric        => ip['metric'],
+        :host_route_metric        => ip['metric'].to_s,
         :ospf_lsa_type            => ip['ospflsatype'],
         :ospf_area                => ip['ospfarea'],
         :virtual_server_rhi_level => ip['vserverrhilevel'],


### PR DESCRIPTION
This should probably be done globally.

Sample output from my catalog runs without this in place:
Netscaler_nsip[X.X.X.X]/host_route_metric: host_route_metric changed '0' to '0'

I dont really expect you guys to accept this pull request, I think the change needs to be made globally in the superclass or transport class. ie Go through the hash created by JSON.parse and find anything that isn't a string and change it to a string with to_s. I'm not 100% sure thats an efficient way to fix this though.
