### PR TITLE
Add support for lbvserver_servicegroup_binding

### DIFF
--- a/lib/puppet/provider/netscaler_lbvserver_servicegroup_binding/rest.rb
+++ b/lib/puppet/provider/netscaler_lbvserver_servicegroup_binding/rest.rb
@@ -1,0 +1,46 @@
+require 'puppet/provider/netscaler_binding'
+
+Puppet::Type.type(:netscaler_lbvserver_servicegroup_binding).provide(:rest, parent: Puppet::Provider::NetscalerBinding) do
+  def netscaler_api_type
+    "lbvserver_servicegroup_binding"
+  end
+
+  def self.instances
+    instances = []
+    lbvservers = Puppet::Provider::Netscaler.call("/config/lbvserver")
+    return [] if lbvservers.nil?
+
+    lbvservers.each do |lbvserver|
+      binds = Puppet::Provider::Netscaler.call("/config/lbvserver_servicegroup_binding/#{lbvserver['name']}") || []
+      binds.each do |bind|
+        instances << new(
+          :ensure => :present,
+          :name   => "#{bind['name']}/#{bind['servicegroupname']}",
+        )
+      end
+    end
+
+    instances
+  end
+
+  mk_resource_methods
+
+  def property_to_rest_mapping
+    {
+    }
+  end
+
+  def per_provider_munge(message)
+    message[:name], message[:servicegroupname] = message[:name].split('/')
+
+    message
+  end
+
+  def destroy
+    toname, fromname = resource.name.split('/').map { |n| URI.escape(n) }
+    result = Puppet::Provider::Netscaler.delete("/config/#{netscaler_api_type}/#{toname}",{'args'=>"servicegroupname:#{fromname}"})
+    @property_hash.clear
+
+    return result
+  end
+end

--- a/lib/puppet/type/netscaler_lbvserver_servicegroup_binding.rb
+++ b/lib/puppet/type/netscaler_lbvserver_servicegroup_binding.rb
@@ -1,0 +1,19 @@
+require 'puppet/property/netscaler_truthy'
+
+Puppet::Type.newtype(:netscaler_lbvserver_servicegroup_binding) do
+  @doc = 'Manage a binding between a loadbalancing vserver and a servicegroup.'
+
+  apply_to_device
+  ensurable
+
+  newparam(:name, :namevar => true) do
+    desc "lbvserver_name/servicegroup_name"
+  end
+
+  autorequire(:netscaler_lbvserver) do
+    self[:name].split('/')[0]
+  end
+  autorequire(:netscaler_servicegroup) do
+    self[:name].split('/')[1]
+  end
+end

--- a/spec/acceptance/netscaler_lbvserver_servicegroup_binding_spec.rb
+++ b/spec/acceptance/netscaler_lbvserver_servicegroup_binding_spec.rb
@@ -1,0 +1,77 @@
+require 'spec_helper_acceptance'
+
+describe 'lbvserver_servicegroup_binding tests' do
+  it 'makes a lbvserver_servicegroup_binding' do
+    pp=<<-EOS
+      netscaler_server { '1_10_server1':
+        ensure  => present,
+        address => '1.10.1.1',
+      }
+
+      netscaler_servicegroup { '1_10_servicegroup1':
+        ensure   => 'present',
+        protocol => 'HTTP',
+      }
+      
+      netscaler_servicegroup_member { "1_10_servicegroup1/1_10_server1:80": 
+        ensure => present, 
+      }
+
+      netscaler_lbvserver { '1_10_lbvserver1':
+        ensure       => 'present',
+        service_type => 'HTTP',
+        ip_address   => '1.10.1.2',
+        port         => '8080',
+        state        => true,
+      }
+
+      netscaler_lbvserver_servicegroup_binding { "1_10_lbvserver1/1_10_servicegroup1": 
+        ensure => present,
+      }
+    EOS
+    make_site_pp(pp)
+    run_device(:allow_changes => true)
+    run_device(:allow_changes => false)
+  end
+
+  it 'makes and deletes a lbvserver_servicegroup_binding' do
+    pp=<<-EOS
+      netscaler_server { '1_10_server1':
+        ensure  => present,
+        address => '1.10.1.1',
+      }
+
+      netscaler_servicegroup { '1_10_servicegroup1':
+        ensure   => 'present',
+        protocol => 'HTTP',
+      }
+    
+      netscaler_servicegroup_member { "1_10_servicegroup1/1_10_server1:80": 
+        ensure => present, 
+      }
+
+      netscaler_lbvserver { '1_10_lbvserver1':
+        ensure       => 'present',
+        service_type => 'HTTP',
+        ip_address   => '1.10.1.2',
+        port         => '8080',
+        state        => true,
+      }
+
+      netscaler_lbvserver_servicegroup_binding { '1_10_lbvserver1/1_10_servicegroup1':
+        ensure => present,
+      }
+    EOS
+
+    pp2=<<-EOS
+      netscaler_lbvserver_servicegroup_binding { '1_10_lbvserver1/1_10_servicegroup1':
+        ensure => 'absent',
+      }
+    EOS
+    make_site_pp(pp)
+    run_device(:allow_changes => true)
+    make_site_pp(pp2)
+    run_device(:allow_changes => true)
+    run_device(:allow_changes => false)
+  end
+end


### PR DESCRIPTION
Ive been using lbvserver_service_binding to create servicegroup bindings which half works, but prefetch is broken and some parameters dont apply to servicegroups. Thought it best to put this in its own type.

I was able to get prefetching working in lbvserver_service_binding but it seemed a bit of a hack, as things like weight dont apply to servicegroup bindings.
