### PR TITLE
Add a type and provider to manage sslservices

### DIFF
--- a/README.md
+++ b/README.md
@@ -183,6 +183,7 @@ The [above example](#set-up-two-load-balanced-web-servers) is a proof-of-concept
 * [`netscaler_sslcertkey`](#type-netscaler_sslcertkey)
 * [`netscaler_sslkeyfile`](#type-netscaler_sslkeyfile)
 * [`netscaler_sslocsresponder`](#type-netscaler_sslocsresponder)
+* [`netscaler_sslservice`](#type-netscaler_sslservice)
 * [`netscaler_sslvserver`](#type-netscaler_sslvserver)
 * [`netscaler_user`](#type-netscaler_user)
 * [`netscaler_vlan`](#type-netscaler_vlan)
@@ -3550,6 +3551,256 @@ Name for the object. Must begin with an ASCII alphabetic or underscore (_) chara
 #####`url`
 
 The URL of the OCSP responder.
+
+###Type: netscaler_sslservice
+
+Sets the advanced SSL configuration for an SSL service.
+
+####Parameters
+
+All parameters, except where otherwise noted, are optional. Their default values are determined by your particular NetScaler setup.
+
+#####`dh`
+
+State of Diffie-Hellman (DH) key exchange. This parameter is not applicable when configuring a backend service.
+
+Possible values: ENABLED, DISABLED
+
+Default value: DISABLED
+
+#####`dh_file`
+
+Name for and, optionally, path to the PEM-format DH parameter file to be installed. /nsconfig/ssl/ is the default path. This parameter is not applicable when configuring a backend service.
+
+#####`dh_count`
+
+Number of interactions, between the client and the NetScaler appliance, after which the DH private-public pair is regenerated. A value of zero (0) specifies infinite use (no refresh). This parameter is not applicable when configuring a backend service.
+
+Minimum value: 0
+
+Maximum value: 65534
+
+#####`dh_key_exp_size_limit`
+
+This option enables the use of NIST recommended (NIST Special Publication 800-56A) bit size for private-key size. For example, for DH params of size 2048bit, the private-key size recommended is 224bits. This is rounded-up to 256bits.
+
+Possible values: ENABLED, DISABLED
+
+Default value: DISABLED
+
+#####`ersa`
+
+State of Ephemeral RSA (eRSA) key exchange. Ephemeral RSA allows clients that support only export ciphers to communicate with the secure server even if the server certificate does not support export clients. The ephemeral RSA key is automatically generated when you bind an export cipher to an SSL or TCP-based SSL virtual server or service. When you remove the export cipher, the eRSA key is not deleted. It is reused at a later date when another export cipher is bound to an SSL or TCP-based SSL virtual server or service. The eRSA key is deleted when the appliance restarts.
+
+This parameter is not applicable when configuring a backend service.
+
+Possible values: ENABLED, DISABLED
+
+Default value: DISABLED
+
+#####`ersa_count`
+
+Refresh count for regeneration of RSA public-key and private-key pair. Zero (0) specifies infinite usage (no refresh).
+
+This parameter is not applicable when configuring a backend service.
+
+Minimum value: 0
+
+Maximum value: 65534
+
+#####`sess_reuse`
+
+State of session reuse. Establishing the initial handshake requires CPU-intensive public key encryption operations. With the ENABLED setting, session key exchange is avoided for session resumption requests received from the client.
+
+Possible values: ENABLED, DISABLED
+
+Default value: ENABLED
+
+#####`sess_timeout`
+
+Time, in seconds, for which to keep the session active. Any session resumption request received after the timeout period will require a fresh SSL handshake and establishment of a new SSL session.
+
+Default value: 300
+
+Minimum value: 0
+
+Maximum value: 4294967294
+
+#####`cipher_redirect`
+
+State of Cipher Redirect. If this parameter is set to ENABLED, you can configure an SSL virtual server or service to display meaningful error messages if the SSL handshake fails because of a cipher mismatch between the virtual server or service and the client.
+
+This parameter is not applicable when configuring a backend service.
+
+Possible values: ENABLED, DISABLED
+
+Default value: DISABLED
+
+#####`cipher_url`
+
+URL of the page to which to redirect the client in case of a cipher mismatch. Typically, this page has a clear explanation of the error or an alternative location that the transaction can continue from.
+
+This parameter is not applicable when configuring a backend service.
+
+#####`sslv2_redirect`
+
+State of SSLv2 Redirect. If this parameter is set to ENABLED, you can configure an SSL virtual server or service to display meaningful error messages if the SSL handshake fails because of a protocol version mismatch between the virtual server or service and the client.
+
+This parameter is not applicable when configuring a backend service.
+
+Possible values: ENABLED, DISABLED
+
+Default value: DISABLED
+
+#####`sslv2_url`
+
+URL of the page to which to redirect the client in case of a protocol version mismatch. Typically, this page has a clear explanation of the error or an alternative location that the transaction can continue from.
+
+This parameter is not applicable when configuring a backend service.
+
+#####`client_auth`
+
+State of client authentication. In service-based SSL offload, the service terminates the SSL handshake if the SSL client does not provide a valid certificate.
+
+This parameter is not applicable when configuring a backend service.
+
+Possible values: ENABLED, DISABLED
+
+Default value: DISABLED
+
+#####`client_cert`
+
+Type of client authentication. If this parameter is set to MANDATORY, the appliance terminates the SSL handshake if the SSL client does not provide a valid certificate. With the OPTIONAL setting, the appliance requests a certificate from the SSL clients but proceeds with the SSL transaction even if the client presents an invalid certificate.
+
+This parameter is not applicable when configuring a backend SSL service.
+
+Caution: Define proper access control policies before changing this setting to Optional.
+
+Possible values: Mandatory, Optional
+
+#####`ssl_redirect`
+
+State of HTTPS redirects for the SSL service.
+
+For an SSL session, if the client browser receives a redirect message, the browser tries to connect to the new location. However, the secure SSL session breaks if the object has moved from a secure site (https://) to an unsecure site (http://). Typically, a warning message appears on the screen, prompting the user to continue or disconnect.
+
+If SSL Redirect is ENABLED, the redirect message is automatically converted from http:// to https:// and the SSL session does not break.
+
+This parameter is not applicable when configuring a backend service.
+
+Possible values: ENABLED, DISABLED
+
+Default value: DISABLED
+
+#####`redirect_port_rewrite`
+
+State of the port rewrite while performing HTTPS redirect. If this parameter is set to ENABLED, and the URL from the server does not contain the standard port, the port is rewritten to the standard.
+
+Possible values: ENABLED, DISABLED
+
+Default value: DISABLED
+
+#####`non_fips_ciphers`
+
+State of usage of ciphers that are not FIPS approved. Valid only for an SSL service bound with a FIPS key and certificate.
+
+Possible values: ENABLED, DISABLED
+
+Default value: DISABLED
+
+#####`ssl2`
+
+State of SSLv2 protocol support for the SSL service.
+
+This parameter is not applicable when configuring a backend service.
+
+Possible values: ENABLED, DISABLED
+
+Default value: DISABLED
+
+#####`ssl3`
+
+State of SSLv3 protocol support for the SSL service.
+
+Possible values: ENABLED, DISABLED
+
+Default value: ENABLED
+
+#####`tls1`
+
+State of TLSv1.0 protocol support for the SSL service.
+
+Possible values: ENABLED, DISABLED
+
+Default value: ENABLED
+
+#####`tls11`
+
+State of TLSv1.1 protocol support for the SSL service. Enabled for Front-end service on MPX-CVM platform only.
+
+Possible values: ENABLED, DISABLED
+
+Default value: ENABLED
+
+#####`tls12`
+
+State of TLSv1.2 protocol support for the SSL service. Enabled for Front-end service on MPX-CVM platform only.
+
+Possible values: ENABLED, DISABLED
+
+Default value: ENABLED
+
+#####`sni_enable`
+
+State of the Server Name Indication (SNI) feature on the virtual server and service-based offload. SNI helps to enable SSL encryption on multiple domains on a single virtual server or service if the domains are controlled by the same organization and share the same second-level domain name. For example, *.sports.net can be used to secure domains such as login.sports.net and help.sports.net.
+
+This parameter is not applicable when configuring a backend service.
+
+Possible values: ENABLED, DISABLED
+
+Default value: DISABLED
+
+#####`server_auth`
+
+State of server authentication support for the SSL service.
+
+Possible values: ENABLED, DISABLED
+
+Default value: DISABLED
+
+#####`common_name`
+
+Name to be checked against the CommonName (CN) field in the server certificate bound to the SSL server
+
+#####`push_enc_trigger`
+
+Trigger encryption on the basis of the PUSH flag value. Available settings function as follows:
+
+* ALWAYS - Any PUSH packet triggers encryption.
+
+* IGNORE - Ignore PUSH packet for triggering encryption.
+
+* MERGE - For a consecutive sequence of PUSH packets, the last PUSH packet triggers encryption.
+
+* TIMER - PUSH packet triggering encryption is delayed by the time defined in the set ssl parameter command or in the Change Advanced SSL Settings dialog box.
+
+Possible values: Always, Merge, Ignore, Timer
+
+#####`send_close_notify`
+
+Enable sending SSL Close-Notify at the end of a transaction
+
+Possible values: YES, NO
+
+Default value: YES
+
+#####`dtls_profile_name`
+
+Name of the DTLS profile that contains DTLS settings for the service.
+
+#####`ssl_profile`
+
+Name of the SSL profile that contains SSL settings for the service.
 
 ###Type: netscaler_sslvserver
 

--- a/lib/puppet/provider/netscaler_sslservice/rest.rb
+++ b/lib/puppet/provider/netscaler_sslservice/rest.rb
@@ -1,0 +1,98 @@
+require 'puppet/provider/netscaler'
+require 'json'
+
+Puppet::Type.type(:netscaler_sslservice).provide(:rest, {:parent => Puppet::Provider::Netscaler}) do
+  # Provider for sslservice: Sets the advanced SSL configuration for an SSL service.
+  def self.instances
+    instances = []
+    sslservices = Puppet::Provider::Netscaler.call('/config/sslservice')
+    return [] if sslservices.nil?
+
+    sslservices.each do |sslservice|
+      instances << new({
+        :ensure                => :present,
+        :name                  => sslservice['servicename'],
+        :cipher_redirect       => sslservice['cipherredirect'],
+        :cipher_url            => sslservice['cipherurl'],
+        :client_auth           => sslservice['clientauth'],
+        :client_cert           => sslservice['clientcert'],
+        :common_name           => sslservice['commonname'],
+        :dh                    => sslservice['dh'],
+        :dh_count              => sslservice['dhcount'],
+        :dh_file               => sslservice['dhfile'],
+        :dh_key_exp_size_limit => sslservice['dhkeyexpsizelimit'],
+        :dtls_profile_name     => sslservice['dtlsprofilename'],
+        :ersa                  => sslservice['ersa'],
+        :ersa_count            => sslservice['ersacount'],
+        :non_fips_ciphers      => sslservice['nonfipsciphers'],
+        :push_enc_trigger      => sslservice['pushenctrigger'],
+        :redirect_port_rewrite => sslservice['redirectportrewrite'],
+        :send_close_notify     => sslservice['sendclosenotify'],
+        :server_auth           => sslservice['serverauth'],
+        :sess_reuse            => sslservice['sessreuse'],
+        :sess_timeout          => sslservice['sesstimeout'],
+        :sni_enable            => sslservice['snienable'],
+        :ssl2                  => sslservice['ssl2'],
+        :ssl3                  => sslservice['ssl3'],
+        :ssl_profile           => sslservice['sslprofile'],
+        :ssl_redirect          => sslservice['sslredirect'],
+        :sslv2_redirect        => sslservice['sslv2redirect'],
+        :sslv2_url             => sslservice['sslv2url'],
+        :tls1                  => sslservice['tls1'],
+        :tls11                 => sslservice['tls11'],
+        :tls12                 => sslservice['tls12'],
+      })
+    end
+
+    instances
+  end
+
+  mk_resource_methods
+
+  # Map irregular attribute names for conversion in the message.
+  def property_to_rest_mapping
+    {
+      :cipher_redirect       => :cipherredirect,
+      :cipher_url            => :cipherurl,
+      :client_auth           => :clientauth,
+      :client_cert           => :clientcert,
+      :common_name           => :commonname,
+      :dh                    => :dh,
+      :dh_count              => :dhcount,
+      :dh_file               => :dhfile,
+      :dh_key_exp_size_limit => :dhkeyexpsizelimit,
+      :dtls_profile_name     => :dtlsprofilename,
+      :ersa                  => :ersa,
+      :ersa_count            => :ersacount,
+      :non_fips_ciphers      => :nonfipsciphers,
+      :push_enc_trigger      => :pushenctrigger,
+      :redirect_port_rewrite => :redirectportrewrite,
+      :send_close_notify     => :sendclosenotify,
+      :server_auth           => :serverauth,
+      :sess_reuse            => :sessreuse,
+      :sess_timeout          => :sesstimeout,
+      :sni_enable            => :snienable,
+      :ssl2                  => :ssl2,
+      :ssl3                  => :ssl3,
+      :ssl_profile           => :sslprofile,
+      :ssl_redirect          => :sslredirect,
+      :sslv2_redirect        => :sslv2redirect,
+      :sslv2_url             => :sslv2url,
+      :tls1                  => :tls1,
+      :tls11                 => :tls11,
+      :tls12                 => :tls12,
+    }
+  end
+
+  def immutable_properties
+    []
+  end
+
+  def per_provider_munge(message)
+    message
+  end
+
+  def netscaler_api_type
+    "sslservice"
+  end
+end

--- a/lib/puppet/type/netscaler_sslservice.rb
+++ b/lib/puppet/type/netscaler_sslservice.rb
@@ -1,0 +1,307 @@
+require_relative('../../puppet/parameter/netscaler_name')
+require_relative('../../puppet/property/netscaler_truthy')
+require_relative('../../puppet/property/netscaler_traffic_domain')
+
+Puppet::Type.newtype(:netscaler_sslservice) do
+  @doc = 'Sets the advanced SSL configuration for an SSL service.'
+
+  apply_to_device
+  ensurable
+
+  newparam(:name, :parent => Puppet::Parameter::NetscalerName, :namevar => true)
+
+  newproperty(:dh, :parent => Puppet::Property::NetscalerTruthy) do
+    truthy_property("State of Diffie-Hellman (DH) key exchange. This parameter is not applicable when configuring a backend service.
+
+Possible values: ENABLED, DISABLED
+
+Default value: DISABLED", ["ENABLED", "DISABLED"])
+
+    munge(&:upcase)
+  end
+
+  newproperty(:dh_file) do
+    desc "Name for and, optionally, path to the PEM-format DH parameter file to be installed. /nsconfig/ssl/ is the default path. This parameter is not applicable when configuring a backend service."
+  end
+
+  newproperty(:dh_count) do
+    desc "Number of interactions, between the client and the NetScaler appliance, after which the DH private-public pair is regenerated. A value of zero (0) specifies infinite use (no refresh). This parameter is not applicable when configuring a backend service.
+
+Minimum value: 0
+
+Maximum value: 65534"
+  end
+
+  newproperty(:dh_key_exp_size_limit, :parent => Puppet::Property::NetscalerTruthy) do
+    truthy_property("This option enables the use of NIST recommended (NIST Special Publication 800-56A) bit size for private-key size. For example, for DH params of size 2048bit, the private-key size recommended is 224bits. This is rounded-up to 256bits.
+
+Possible values: ENABLED, DISABLED
+
+Default value: DISABLED", ["ENABLED", "DISABLED"])
+
+    munge(&:upcase)
+  end
+
+  newproperty(:ersa, :parent => Puppet::Property::NetscalerTruthy) do
+    truthy_property("State of Ephemeral RSA (eRSA) key exchange. Ephemeral RSA allows clients that support only export ciphers to communicate with the secure server even if the server certificate does not support export clients. The ephemeral RSA key is automatically generated when you bind an export cipher to an SSL or TCP-based SSL virtual server or service. When you remove the export cipher, the eRSA key is not deleted. It is reused at a later date when another export cipher is bound to an SSL or TCP-based SSL virtual server or service. The eRSA key is deleted when the appliance restarts.
+
+This parameter is not applicable when configuring a backend service.
+
+Possible values: ENABLED, DISABLED
+
+Default value: DISABLED", ["ENABLED", "DISABLED"])
+
+    munge(&:upcase)
+  end
+
+  newproperty(:ersa_count) do
+    desc "Refresh count for regeneration of RSA public-key and private-key pair. Zero (0) specifies infinite usage (no refresh). 
+
+This parameter is not applicable when configuring a backend service.
+
+Minimum value: 0
+
+Maximum value: 65534"
+  end
+
+  newproperty(:sess_reuse, :parent => Puppet::Property::NetscalerTruthy) do
+    truthy_property("State of session reuse. Establishing the initial handshake requires CPU-intensive public key encryption operations. With the ENABLED setting, session key exchange is avoided for session resumption requests received from the client.
+
+Possible values: ENABLED, DISABLED
+
+Default value: ENABLED", ["ENABLED", "DISABLED"])
+
+    munge(&:upcase)
+  end
+
+  newproperty(:sess_timeout) do
+    desc "Time, in seconds, for which to keep the session active. Any session resumption request received after the timeout period will require a fresh SSL handshake and establishment of a new SSL session.
+
+Default value: 300
+
+Minimum value: 0
+
+Maximum value: 4294967294"
+  end
+
+  newproperty(:cipher_redirect, :parent => Puppet::Property::NetscalerTruthy) do
+    truthy_property("State of Cipher Redirect. If this parameter is set to ENABLED, you can configure an SSL virtual server or service to display meaningful error messages if the SSL handshake fails because of a cipher mismatch between the virtual server or service and the client.
+
+This parameter is not applicable when configuring a backend service.
+
+Possible values: ENABLED, DISABLED
+
+Default value: DISABLED", ["ENABLED", "DISABLED"])
+
+    munge(&:upcase)
+  end
+
+  newproperty(:cipher_url) do
+    desc "URL of the page to which to redirect the client in case of a cipher mismatch. Typically, this page has a clear explanation of the error or an alternative location that the transaction can continue from.
+
+This parameter is not applicable when configuring a backend service."
+  end
+
+  newproperty(:sslv2_redirect, :parent => Puppet::Property::NetscalerTruthy) do
+    truthy_property("State of SSLv2 Redirect. If this parameter is set to ENABLED, you can configure an SSL virtual server or service to display meaningful error messages if the SSL handshake fails because of a protocol version mismatch between the virtual server or service and the client.
+
+This parameter is not applicable when configuring a backend service.
+
+Possible values: ENABLED, DISABLED
+
+Default value: DISABLED", ["ENABLED", "DISABLED"])
+
+    munge(&:upcase)
+  end
+
+  newproperty(:sslv2_url) do
+    desc "URL of the page to which to redirect the client in case of a protocol version mismatch. Typically, this page has a clear explanation of the error or an alternative location that the transaction can continue from.
+
+This parameter is not applicable when configuring a backend service."
+  end
+
+  newproperty(:client_auth, :parent => Puppet::Property::NetscalerTruthy) do
+    truthy_property("State of client authentication. In service-based SSL offload, the service terminates the SSL handshake if the SSL client does not provide a valid certificate. 
+
+This parameter is not applicable when configuring a backend service.
+
+Possible values: ENABLED, DISABLED
+
+Default value: DISABLED", ["ENABLED", "DISABLED"])
+
+    munge(&:upcase)
+  end
+
+  newproperty(:client_cert) do
+    desc "Type of client authentication. If this parameter is set to MANDATORY, the appliance terminates the SSL handshake if the SSL client does not provide a valid certificate. With the OPTIONAL setting, the appliance requests a certificate from the SSL clients but proceeds with the SSL transaction even if the client presents an invalid certificate.
+
+This parameter is not applicable when configuring a backend SSL service.
+
+Caution: Define proper access control policies before changing this setting to Optional.
+
+Possible values: Mandatory, Optional"
+
+    validate do |value|
+      if ! [:MANDATORY, :OPTIONAL].any?{ |s| s.to_s.eql? value }
+        fail ArgumentError, "Valid options: MANDATORY, OPTIONAL"
+      end
+    end
+
+    munge(&:upcase)
+  end
+
+  newproperty(:ssl_redirect, :parent => Puppet::Property::NetscalerTruthy) do
+    truthy_property("State of HTTPS redirects for the SSL service. 
+
+For an SSL session, if the client browser receives a redirect message, the browser tries to connect to the new location. However, the secure SSL session breaks if the object has moved from a secure site (https://) to an unsecure site (http://). Typically, a warning message appears on the screen, prompting the user to continue or disconnect.
+
+If SSL Redirect is ENABLED, the redirect message is automatically converted from http:// to https:// and the SSL session does not break.
+
+This parameter is not applicable when configuring a backend service.
+
+Possible values: ENABLED, DISABLED
+
+Default value: DISABLED", ["ENABLED", "DISABLED"])
+
+    munge(&:upcase)
+  end
+
+  newproperty(:redirect_port_rewrite, :parent => Puppet::Property::NetscalerTruthy) do
+    truthy_property("State of the port rewrite while performing HTTPS redirect. If this parameter is set to ENABLED, and the URL from the server does not contain the standard port, the port is rewritten to the standard.
+
+Possible values: ENABLED, DISABLED
+
+Default value: DISABLED", ["ENABLED", "DISABLED"])
+
+    munge(&:upcase)
+  end
+
+  newproperty(:non_fips_ciphers, :parent => Puppet::Property::NetscalerTruthy) do
+    truthy_property("State of usage of ciphers that are not FIPS approved. Valid only for an SSL service bound with a FIPS key and certificate.
+
+Possible values: ENABLED, DISABLED
+
+Default value: DISABLED", ["ENABLED", "DISABLED"])
+
+    munge(&:upcase)
+  end
+
+  newproperty(:ssl2, :parent => Puppet::Property::NetscalerTruthy) do
+    truthy_property("State of SSLv2 protocol support for the SSL service.
+
+This parameter is not applicable when configuring a backend service.
+
+Possible values: ENABLED, DISABLED
+
+Default value: DISABLED", ["ENABLED", "DISABLED"])
+
+    munge(&:upcase)
+  end
+
+  newproperty(:ssl3, :parent => Puppet::Property::NetscalerTruthy) do
+    truthy_property("State of SSLv3 protocol support for the SSL service.
+
+Possible values: ENABLED, DISABLED
+
+Default value: ENABLED", ["ENABLED", "DISABLED"])
+
+    munge(&:upcase)
+  end
+
+  newproperty(:tls1, :parent => Puppet::Property::NetscalerTruthy) do
+    truthy_property("State of TLSv1.0 protocol support for the SSL service.
+
+Possible values: ENABLED, DISABLED
+
+Default value: ENABLED", ["ENABLED", "DISABLED"])
+
+    munge(&:upcase)
+  end
+
+  newproperty(:tls11, :parent => Puppet::Property::NetscalerTruthy) do
+    truthy_property("State of TLSv1.1 protocol support for the SSL service. Enabled for Front-end service on MPX-CVM platform only.
+
+Possible values: ENABLED, DISABLED
+
+Default value: ENABLED", ["ENABLED", "DISABLED"])
+
+    munge(&:upcase)
+  end
+
+  newproperty(:tls12, :parent => Puppet::Property::NetscalerTruthy) do
+    truthy_property("State of TLSv1.2 protocol support for the SSL service. Enabled for Front-end service on MPX-CVM platform only.
+
+Possible values: ENABLED, DISABLED
+
+Default value: ENABLED", ["ENABLED", "DISABLED"])
+
+    munge(&:upcase)
+  end
+
+  newproperty(:sni_enable, :parent => Puppet::Property::NetscalerTruthy) do
+    truthy_property("State of the Server Name Indication (SNI) feature on the virtual server and service-based offload. SNI helps to enable SSL encryption on multiple domains on a single virtual server or service if the domains are controlled by the same organization and share the same second-level domain name. For example, *.sports.net can be used to secure domains such as login.sports.net and help.sports.net.
+
+This parameter is not applicable when configuring a backend service.
+
+Possible values: ENABLED, DISABLED
+
+Default value: DISABLED", ["ENABLED", "DISABLED"])
+
+    munge(&:upcase)
+  end
+
+  newproperty(:server_auth, :parent => Puppet::Property::NetscalerTruthy) do
+    truthy_property("State of server authentication support for the SSL service.
+
+Possible values: ENABLED, DISABLED
+
+Default value: DISABLED", ["ENABLED", "DISABLED"])
+
+    munge(&:upcase)
+  end
+
+  newproperty(:common_name) do
+    desc "Name to be checked against the CommonName (CN) field in the server certificate bound to the SSL server"
+  end
+
+  newproperty(:push_enc_trigger) do
+    desc "Trigger encryption on the basis of the PUSH flag value. Available settings function as follows:
+
+* ALWAYS - Any PUSH packet triggers encryption.
+
+* IGNORE - Ignore PUSH packet for triggering encryption.
+
+* MERGE - For a consecutive sequence of PUSH packets, the last PUSH packet triggers encryption.
+
+* TIMER - PUSH packet triggering encryption is delayed by the time defined in the set ssl parameter command or in the Change Advanced SSL Settings dialog box.
+
+Possible values: Always, Merge, Ignore, Timer"
+
+    validate do |value|
+      if ! [:ALWAYS, :MERGE, :IGNORE, :TIMER].any?{ |s| s.to_s.eql? value }
+        fail ArgumentError, "Valid options: ALWAYS, MERGE, IGNORE, TIMER"
+      end
+    end
+
+    munge(&:upcase)
+  end
+
+  newproperty(:send_close_notify, :parent => Puppet::Property::NetscalerTruthy) do
+    truthy_property("Enable sending SSL Close-Notify at the end of a transaction
+
+Possible values: YES, NO
+
+Default value: YES", ["YES", "NO"])
+
+    munge(&:upcase)
+  end
+
+  newproperty(:dtls_profile_name) do
+    desc "Name of the DTLS profile that contains DTLS settings for the service."
+  end
+
+  newproperty(:ssl_profile) do
+    desc "Name of the SSL profile that contains SSL settings for the service."
+  end
+
+end


### PR DESCRIPTION
Feedback please: should I use eg. `cipher_details` rather than `cipherdetails`?
