### PR TITLE
Rename sslvserver to sslvserver_sslcertkey_binding

### DIFF
--- a/README.md
+++ b/README.md
@@ -183,7 +183,7 @@ The [above example](#set-up-two-load-balanced-web-servers) is a proof-of-concept
 * [`netscaler_sslcertkey`](#type-netscaler_sslcertkey)
 * [`netscaler_sslkeyfile`](#type-netscaler_sslkeyfile)
 * [`netscaler_sslocsresponder`](#type-netscaler_sslocsresponder)
-* [`netscaler_sslvserver`](#type-netscaler_sslvserver)
+* [`netscaler_sslvserver_sslcertkey_binding`](#type-netscaler_sslvserver_sslcertkey_binding)
 * [`netscaler_user`](#type-netscaler_user)
 * [`netscaler_vlan`](#type-netscaler_vlan)
 * [`netscaler_vlan_nsip_binding`](#type-netscaler_vlan_nsip_binding)
@@ -3556,9 +3556,9 @@ Name for the object. Must begin with an ASCII alphabetic or underscore (_) chara
 
 The URL of the OCSP responder.
 
-###Type: netscaler_sslvserver
+###Type: netscaler_sslvserver_sslcertkey_binding
 
-Binds the sslvserver and the certkeyname.
+Binds the sslvserver and the certkey.
 
 ####Parameters
 

--- a/lib/puppet/provider/netscaler_sslvserver_sslcertkey_binding/rest.rb
+++ b/lib/puppet/provider/netscaler_sslvserver_sslcertkey_binding/rest.rb
@@ -2,9 +2,12 @@ require 'puppet/provider/netscaler'
 
 require 'json'
 
-Puppet::Type.type(:netscaler_sslvserver).provide(:rest, {:parent => Puppet::Provider::Netscaler}) do
-  def netscaler_api_type
+Puppet::Type.type(:netscaler_sslvserver_sslcertkey_binding).provide(:rest, {:parent => Puppet::Provider::Netscaler}) do
+	def self.netscaler_api_type
     "sslvserver_sslcertkey_binding"
+  end
+  def netscaler_api_type
+		self.class.netscaler_api_type
   end
 
   def self.instances
@@ -13,7 +16,7 @@ Puppet::Type.type(:netscaler_sslvserver).provide(:rest, {:parent => Puppet::Prov
     return [] if sslvservers.nil?
 
     sslvservers.each do |sslvserver|
-      binds = Puppet::Provider::Netscaler.call("/config/sslvserver_sslcertkey_binding/#{sslvserver['vservername']}") || []
+      binds = Puppet::Provider::Netscaler.call("/config/#{netscaler_api_type}/#{sslvserver['vservername']}") || []
 
       binds.each do |bind|
         instances << new({

--- a/lib/puppet/type/netscaler_sslvserver_sslcertkey_binding.rb
+++ b/lib/puppet/type/netscaler_sslvserver_sslcertkey_binding.rb
@@ -2,14 +2,14 @@ require_relative('../../puppet/parameter/netscaler_name')
 require_relative('../../puppet/property/netscaler_traffic_domain')
 require_relative('../../puppet/property/netscaler_truthy')
 
-Puppet::Type.newtype(:netscaler_sslvserver) do
-  @doc = 'Configuration for SSL virtual server resource.'
+Puppet::Type.newtype(:netscaler_sslvserver_sslcertkey_binding) do
+  @doc = 'Configuration for SSL virtual server resource - binding with certkey.'
 
   apply_to_device
   ensurable
 
   newparam(:name, :parent => Puppet::Parameter::NetscalerName, :namevar => true)
-  desc "This is the binding of sslvserver/certkeyname"
+  desc "This is the binding of sslvserver/certkey"
   #XXX Validate with the below
   #ensure: change from absent to present failed: Could not set 'present' on ensure: REST failure: HTTP status code 400 detected.  Body of failure is: { "errorcode": 1075, "message": "Invalid name; names must begin with an alphanumeric character or underscore and must contain only alphanumerics, '_', '#', '.', ' ', ':', '@', '=' or '-' [name, hunner's website]", "severity": "ERROR" } at 55:/etc/puppetlabs/puppet/environments/produc
 
@@ -17,7 +17,7 @@ Puppet::Type.newtype(:netscaler_sslvserver) do
     desc "The state of the CRL check parameter. (Mandatory/Optional).
 Possible values = Mandatory, Optional"
   end
-  
+
   newproperty(:ca) do
     desc "CA certificate."
   end

--- a/spec/acceptance/netscaler_sslvserver_sslcertkey_binding_spec.rb
+++ b/spec/acceptance/netscaler_sslvserver_sslcertkey_binding_spec.rb
@@ -1,8 +1,8 @@
 require 'spec_helper_acceptance'
 
-describe 'sslvserver' do
+describe 'sslvserver_sslcertkey_binding' do
   #we need to upload a key and cert file, for this test to work
-#  it 'makes a sslvserver' do
+#  it 'makes a sslvserver_sslcertkey_binding' do
 #    pp=<<-EOS
 #netscaler_file { 'server.cert':
 #        ensure       => 'present',
@@ -58,20 +58,20 @@ describe 'sslvserver' do
 #        port         => '8080',
 #        state        => true,
 #}
-#netscaler_sslvserver { 'lbvserver_ssl/test_sslcertkey':
+#netscaler_sslvserver_sslcertkey_binding { 'lbvserver_ssl/test_sslcertkey':
 #  ensure => 'present',
-#} 
+#}
 #    EOS
 #    make_site_pp(pp)
 #    run_device(:allow_changes => true)
 #    run_device(:allow_changes => false)
 #  end
 #
-#  it 'deletes a sslvserver' do
+#  it 'deletes a sslvserver_sslcertkey_binding' do
 #    pp=<<-EOS
-#netscaler_sslvserver { 'lbvserver_ssl/test_sslcertkey':
+#netscaler_sslvserver_sslcertkey_binding { 'lbvserver_ssl/test_sslcertkey':
 #  ensure => 'absent',
-#} 
+#}
 #    EOS
 #    make_site_pp(pp)
 #    run_device(:allow_changes => true)


### PR DESCRIPTION
The `sslvserver` is something else, and I also have
`sslvserver_ecccurve_binding` and `sslvserver_sslcipher_binding` coming
up.

This change is not backward compatible - you _will have_ to change
`netscaler_sslvserver` to `netscaler_sslvserver_sslcertkey_binding` ...

I would appreciate some feedback whether this change is acceptable or not, or how I should proceed otherwise. I will already make another PR for the new sslvserver
