### PR TITLE
Fix policylabel self instances load

### DIFF
--- a/lib/puppet/provider/netscaler_csvserver_rewritepolicy_binding/rest.rb
+++ b/lib/puppet/provider/netscaler_csvserver_rewritepolicy_binding/rest.rb
@@ -22,6 +22,12 @@ Puppet::Type.type(:netscaler_csvserver_rewritepolicy_binding).provide(:rest, {:p
             labeltype = "Response"
           when 'policylabel'
             policylabel = bind['labelname']
+            case bind['bindpoint']
+              when 'REQUEST'
+                labeltype = 'Request'
+              when "RESPONSE"
+                labeltype = 'Response'
+            end
         end
         instances << new({
           :ensure               => :present,


### PR DESCRIPTION
This fixes some issues I'm seeing where puppet continually wants to change "choose_type" on existing resources when using invoke_policy_label.

Prior to this code change seeing this from puppet on every run:
Notice: /Stage[main]/Lb/Lb::Config[AAAAA.csu.edu.au]/Netscaler_csvserver_rewritepolicy_binding[cs-AAA.csu.edu.au-https/NOPOLICY-REWRITE]/choose_type: current_value absent, should be Request (noop)

Im not sure why we aren't mapping bindpoint => choose_type in all cases as a quick check it seems to be set correctly for a normal rewritepolicy binding.
