### PR TITLE
Fix lbmonitor units calculation

### DIFF
--- a/lib/puppet/provider/netscaler_lbmonitor/rest.rb
+++ b/lib/puppet/provider/netscaler_lbmonitor/rest.rb
@@ -11,19 +11,29 @@ Puppet::Type.type(:netscaler_lbmonitor).provide(:rest, {:parent => Puppet::Provi
     monitors = Puppet::Provider::Netscaler.call('/config/lbmonitor')
     return [] if monitors.nil?
 
+    unit_map = {
+      'SEC' => 1,
+      'MIN' => 60
+    }
+
     monitors.each do |monitor|
+      interval = monitor['interval'].to_i * unit_map[monitor['units3']]
+      resptimeout = monitor['resptimeout'].to_i * unit_map[monitor['units4']]
+      downtime = monitor['downtime'].to_i * unit_map[monitor['units2']]
+      deviation = monitor['deviation'].to_i * unit_map[monitor['units1']]
+      
       instances << new({
         :ensure                         => :present,
         ## Standard
         :name                           => monitor['monitorname'],
         :type                           => monitor['type'],
-        :interval                       => monitor['interval'].to_i,
+        :interval                       => interval,
         :destination_ip                 => monitor['destip'],
-        :response_timeout               => monitor['resptimeout'],
+        :response_timeout               => resptimeout,
         :destination_port               => monitor['destport'],
-        :down_time                      => monitor['downtime'],
+        :down_time                      => downtime,
         #:dynamic_timeout                      => monitor['dynamicresponsetimeout'],
-        :deviation                      => monitor['deviation'],
+        :deviation                      => deviation,
         #:dynamic_interval                     => monitor['dynamicinterval'],
         :retries                        => monitor['retries'],
         :resp_timeout_threshold         => monitor['resptimoutthresh'],


### PR DESCRIPTION
This fixes an issue I'm seeing where puppet runs continually want to change "interval" when its set to 60 seconds. The REST call is returning "1" and a unit of MIN rather than SEC. This looks to be an issue for any of four params in the UI that have a dropdown for second/minute/millisecond.

Sample puppet output (when interval => 60):
Netscaler_lbmonitor[http-cms-testmessage]/interval: current_value 1, should be 60 (noop)

I had a few tries at squashing these commits locally but failed. I'm a bit of a git newbie. Hope this can be merged ok.
