### PR TITLE
sslvserver: add ssl parameters

### DIFF
--- a/lib/puppet/provider/netscaler_sslvserver_param/rest.rb
+++ b/lib/puppet/provider/netscaler_sslvserver_param/rest.rb
@@ -1,0 +1,54 @@
+require 'puppet/provider/netscaler'
+
+require 'json'
+
+Puppet::Type.type(:netscaler_sslvserver_param).provide(:rest, {:parent => Puppet::Provider::Netscaler}) do
+  def netscaler_api_type
+    "sslvserver"
+  end
+
+  def self.instances
+    instances = []
+    sslvservers = Puppet::Provider::Netscaler.call('/config/sslvserver')
+    return [] if sslvservers.nil?
+
+    sslvservers.each do |sslvserver|
+      instances << new({
+        :ensure      => :present,
+        :name        => sslvserver['vservername'],
+        :ssl3        => sslvserver['ssl3'],
+        :sslredirect => sslvserver['sslredirect'],
+      })
+    end
+
+    instances
+  end
+
+  mk_resource_methods
+
+  # Map for conversion in the message.
+  def property_to_rest_mapping
+    {
+      :name          => :vservername,
+    }
+  end
+
+  def immutable_properties
+    [
+    ]
+  end
+
+  def destroy
+    vservername = resource.name
+    result = Puppet::Provider::Netscaler.delete("/config/#{netscaler_api_type}", {'args'=>"vservername:#{vservername}"})
+    @property_hash.clear
+    return result
+  end
+
+  def per_provider_munge(message)
+    message[:vservername] = message[:name]
+    message.delete(:name)
+
+    message
+  end
+end

--- a/lib/puppet/type/netscaler_sslvserver_param.rb
+++ b/lib/puppet/type/netscaler_sslvserver_param.rb
@@ -1,0 +1,22 @@
+require_relative('../../puppet/parameter/netscaler_name')
+require_relative('../../puppet/property/netscaler_traffic_domain')
+require_relative('../../puppet/property/netscaler_truthy')
+
+Puppet::Type.newtype(:netscaler_sslvserver_param) do
+  @doc = 'Configuration for SSL virtual server resource. SSL parameters.'
+
+  apply_to_device
+  ensurable
+
+  newparam(:name, :parent => Puppet::Parameter::NetscalerName, :namevar => true)
+  desc "This is the binding of sslvserver"
+
+  newproperty(:ssl3) do
+    desc "State of SSLv3 protocol support for the SSL Virtual Server."
+  end
+
+  newproperty(:sslredirect) do
+    desc "State of HTTPS redirects for the SSL virtual server."
+  end
+
+end


### PR DESCRIPTION
ssl3 and sslredirect parameters added 
example:
```
netscaler_sslvserver_param { 'myserver':
  ensure      => 'present',
  ssl3        => 'DISABLED',
  sslredirect => 'ENABLED',
}
```