### PR TITLE
(PUP-8590) convert facts hash keys from symbols to strings

### DIFF
--- a/lib/puppet/util/network_device/netscaler/facts.rb
+++ b/lib/puppet/util/network_device/netscaler/facts.rb
@@ -14,30 +14,30 @@ class Puppet::Util::NetworkDevice::Netscaler::Facts
     facts = {}
     result = @transport.call('/stat/ns')
     [
-      :cpuusage,
-      :memuseinmb,
-      :numcpus,
-      :starttime,
+      'cpuusage',
+      'memuseinmb',
+      'numcpus',
+      'starttime',
     ].each do |fact|
       facts[fact] = result[fact.to_s]
     end
     result = @transport.call('/config/nsconfig')
     [
-      :ipaddress,
-      :netmask,
-      :systemtype,
-      :primaryip,
-      :timezone,
-      :lastconfigchangedtime,
-      :lastconfigsavetime,
-      :systemtime,
+      'ipaddress',
+      'netmask',
+      'systemtype',
+      'primaryip',
+      'timezone',
+      'lastconfigchangedtime',
+      'lastconfigsavetime',
+      'systemtime',
     ].each do |fact|
       facts[fact] = result[fact.to_s]
     end
-    facts[:version]         = @transport.call('/config/nsversion')['version']
-    facts[:macaddress]      = @transport.call('/config/Interface').first['mac']
-    facts[:operatingsystem] = :Netscaler
-    #facts[:fqdn]            = facts[:hostname]
+    facts['version']         = @transport.call('/config/nsversion')['version']
+    facts['macaddress']      = @transport.call('/config/Interface').first['mac']
+    facts['operatingsystem'] = 'Netscaler'
+    #facts['fqdn']           = facts[:hostname]
 
     return facts
   end


### PR DESCRIPTION
Prior to this commit, the facts hash keys were defined using Symbols.
which is incompatible (at minimum) with 'puppet device --apply'.

With this commit, the facts hash keys are defined using Strings.